### PR TITLE
fixes accessibilty issue with non-displayed checkboxes

### DIFF
--- a/web/static/css/app.css
+++ b/web/static/css/app.css
@@ -3,7 +3,7 @@
 /*fonts*/
 
 body {
-  font-family: 'Segoe UI','NunitoSans',Arial,sans-serif; 
+  font-family: 'Segoe UI','NunitoSans',Arial,sans-serif;
   color: #242F4F;
   min-height: 100%;
   height: 100%;
@@ -45,6 +45,10 @@ body {
 .checked-fill:checked~label {
   background-color: #FAB781;
  }
+
+.checked-fill:focus~label {
+  outline: auto 5px -webkit-focus-ring-color;
+}
 
 /*color palette*/
 

--- a/web/templates/homepage/index.html.eex
+++ b/web/templates/homepage/index.html.eex
@@ -31,7 +31,7 @@
   <%= inputs_for f, :audience, [as: :audience], fn fa -> %>
     <%= for tag <- @aud_tags do %>
       <div class="dib">
-        <%= checkbox fa, String.to_atom(tag), value: @conn.body_params["audience"][tag], class: "checked-fill dn" %>
+        <%= checkbox fa, String.to_atom(tag), value: @conn.body_params["audience"][tag], class: "checked-fill absolute o-0" %>
         <%= label fa, String.to_atom(tag), class: "b--lm-orange ba br2 ph2 pv1 dib" %>
       </div>
     <% end %>
@@ -41,7 +41,7 @@
   <%= inputs_for f, :content, [as: :content], fn fcon -> %>
     <%= for tag <- @con_tags do %>
     <div class="dib">
-      <%= checkbox fcon, String.to_atom(tag), value: @conn.body_params["content"][tag], class: "checked-fill dn" %>
+      <%= checkbox fcon, String.to_atom(tag), value: @conn.body_params["content"][tag], class: "checked-fill absolute o-0" %>
         <%= label fcon, String.to_atom(tag), class: "b--lm-orange ba br2 ph2 pv1 dib" %>
       </div>
     <% end %>


### PR DESCRIPTION
Hides checkbox without using display:none (I was wrong about it being fine for accessibility. It's ok for screen readers but no good for keyboard navigation)
Also highlights the label of the keyboard-selected checkbox.