### PR TITLE
adds padding back for results list 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /db
 /deps
 /*.ez
+npm-debug.log*
 
 # Generated on crash by the VM
 erl_crash.dump

--- a/web/static/css/app.css
+++ b/web/static/css/app.css
@@ -7,6 +7,7 @@ body {
   color: #242F4F;
   min-height: 100%;
   height: 100%;
+  margin: 0;
 }
 
 @font-face {

--- a/web/templates/homepage/show.html.eex
+++ b/web/templates/homepage/show.html.eex
@@ -1,38 +1,40 @@
-<div class="w-60-ns center">
-  <p class="fw9 tl">Showing <%= number_of_results(@resources) %></p>
-</div>
-<%= for resource <- @resources do %>
-  <%= if resource[:url] do %>
-    <div class="br1 shadow-2 ph3 pt3 pb2 mt4 tl w-60-ns center" id="resource_<%= resource.id %>">
-      <h2 class="mv0"><%= resource[:heading] %></h2>
-      <div class="overflow-x-scroll">
-        <%= link resource.url, to: resource.url, class: "link f6 lm-turquoise" %>
-      </div>
-      <div class="mt1">
-        <%= for tag <- resource.tags do %>
+<div class="pa3">
+  <div class="w-60-ns center">
+    <p class="fw9 tl">Showing <%= number_of_results(@resources) %></p>
+  </div>
+  <%= for resource <- @resources do %>
+    <%= if resource[:url] do %>
+      <div class="br1 shadow-2 ph3 pt3 pb2 mt4 tl w-60-ns center" id="resource_<%= resource.id %>">
+        <h2 class="mv0"><%= resource[:heading] %></h2>
+        <div class="overflow-x-scroll">
+          <%= link resource.url, to: resource.url, class: "link f6 lm-turquoise" %>
+        </div>
+        <div class="mt1">
+          <%= for tag <- resource.tags do %>
           <span class="b--lm-orange ba br2 ph2 pv1 lh-tag"><%= tag %></span>
-        <% end %>
-      </div>
-      <%= raw(resource[:body]) %>
-      <div class="bt b--lm-grey">
-        <p class="b">Would you recommend this?</p>
-        <div class="w-60 dib">
-          <%= form_for @conn, homepage_path(@conn, :like, resource.id) <> "#resource_#{resource.id}", [as: :like, class: "dib w-30 ph2"], fn _f -> %>
+          <% end %>
+        </div>
+        <%= raw(resource[:body]) %>
+        <div class="bt b--lm-grey">
+          <p class="b">Would you recommend this?</p>
+          <div class="w-60 dib">
+            <%= form_for @conn, homepage_path(@conn, :like, resource.id) <> "#resource_#{resource.id}", [as: :like, class: "dib w-30 ph2"], fn _f -> %>
             <button type="submit" class="like w-100 h2 bn bg-white"></button>
-          <%= end %>
-          <div class="dib mb3 v-mid tl"><span><%= resource.likes %></span></div>
-          <%= form_for @conn, homepage_path(@conn, :dislike, resource.id) <> "#resource_#{resource.id}", [as: :dislike, class: "dib w-30 ph2"], fn _f -> %>
+            <%= end %>
+            <div class="dib mb3 v-mid tl"><span><%= resource.likes %></span></div>
+            <%= form_for @conn, homepage_path(@conn, :dislike, resource.id) <> "#resource_#{resource.id}", [as: :dislike, class: "dib w-30 ph2"], fn _f -> %>
             <button type="submit" class="dislike w-100 h2 bn bg-white"></button>
-          <%= end %>
-        </div>
-        <div class="dib tr w-30">
-          <button class="share w-30 h2 bn bg-white"></button>
+            <%= end %>
+          </div>
+          <div class="dib tr w-30">
+            <button class="share w-30 h2 bn bg-white"></button>
+          </div>
         </div>
       </div>
-    </div>
-  <%= else %>
-    <div>
-      <%= link resource.heading, to: article_path(@conn, :show, resource.id) %>
-    </div>
+      <%= else %>
+      <div>
+        <%= link resource.heading, to: article_path(@conn, :show, resource.id) %>
+      </div>
+    <% end %>
   <% end %>
-<% end %>
+</div>


### PR DESCRIPTION
Removing the padding from the filter block in https://github.com/LDMW/app/pull/114/commits/0316357ce22e925a5e0fecdacc720befe7e21040 also removed the padding for the result cards. 
This adds a div just around the results with its own padding