### PR TITLE
makes sleep assessment section look better on desktop 

### DIFF
--- a/web/templates/homepage/index.html.eex
+++ b/web/templates/homepage/index.html.eex
@@ -5,8 +5,8 @@
   </div>
 </section>
 
-<section class="pt1 pb3 pt5-l ph4 ph5-m ph6-l lm-bg-dark-blue tc">
-  <p class="white tl">
+<section class="pt1 pb3 ph4 ph5-m ph6-l lm-bg-dark-blue tc">
+  <p class="white tl tc-l">
     Take our <span class="b">clinically approved</span> sleep self-assessment
   </p>
   <%= component "secondary_button", value: "Take assessment", to: "/info/coming-soon"%>


### PR DESCRIPTION
ref #139
old: 
<img width="1232" alt="screen shot 2017-05-11 at 11 11 21" src="https://cloud.githubusercontent.com/assets/4185328/25944330/d21925f4-363a-11e7-881b-ab9ef8021cfb.png">
new: 
<img width="1147" alt="screen shot 2017-05-11 at 11 53 10" src="https://cloud.githubusercontent.com/assets/8939909/25945879/8d278520-3640-11e7-8c90-0cc5a620f13b.png">