### PR TITLE
uses correct font spacing for "x results"

### DIFF
--- a/web/static/css/app.css
+++ b/web/static/css/app.css
@@ -3,8 +3,9 @@
 /*fonts*/
 
 body {
-  font-family: 'Segoe UI','NunitoSans',Arial,sans-serif;
-  color: #242F4F;
+  font-family: 'NunitoSans', Arial, sans-serif;
+  letter-spacing: 0.7px;
+  color: #242E50;
   min-height: 100%;
   height: 100%;
   margin: 0;
@@ -19,13 +20,17 @@ body {
 
 @font-face {
   font-family: 'Segoe UI';
-  src: url(/fonts/segoe/SEGOEUI.TTF) format('truetype');
+  src: url('/fonts/segoe/SEGOEUI.TTF') format('truetype');
   font-weight: normal;
   font-style: normal;
 }
 
 .font {
-  font-family: 'Segoe UI','NunitoSans',Arial,sans-serif;
+  font-family: 'Segoe UI', 'NunitoSans', Arial,sans-serif;
+}
+
+h1, h2 {
+  font-family: 'Segoe UI', sans-serif;
 }
 
 /*elements*/
@@ -40,6 +45,10 @@ body {
 
 .cover-img {
   background-image: url("/images/background-img.png");
+}
+
+.cover-img p {
+  letter-spacing: 1.5px;
 }
 
 /* Phoenix flash messages */

--- a/web/templates/homepage/show.html.eex
+++ b/web/templates/homepage/show.html.eex
@@ -1,6 +1,6 @@
 <div class="pa3">
   <div class="w-60-ns center">
-    <p class="fw9 tl">Showing <%= number_of_results(@resources) %></p>
+    <p class="tl b">Showing <%= number_of_results(@resources) %></p>
   </div>
   <%= for resource <- @resources do %>
     <%= if resource[:url] do %>


### PR DESCRIPTION
ref #142 
old: 
<img width="220" alt="screen shot 2017-05-11 at 11 16 48" src="https://cloud.githubusercontent.com/assets/4185328/25944494/6f63d034-363b-11e7-96a8-69ca910c149a.png">
new:
<img width="222" alt="screen shot 2017-05-11 at 14 37 50" src="https://cloud.githubusercontent.com/assets/8939909/25952046/70612042-3657-11e7-8e2f-116cd956b6b7.png">

design:
<img width="315" alt="screen shot 2017-05-11 at 11 17 03" src="https://cloud.githubusercontent.com/assets/4185328/25944499/7552a966-363b-11e7-833e-55e99dbe2ef5.png">


