### PR TITLE
makes brunch css compilation order match local order

### DIFF
--- a/brunch-config.js
+++ b/brunch-config.js
@@ -22,7 +22,11 @@ exports.config = {
     stylesheets: {
       joinTo: "css/app.css",
       order: {
-        after: ["web/static/css/app.css"] // concat app.css last
+        before: [
+          "web/static/css/app.css",
+          "web/static/tachyons-word-break.min.css",
+          "web/static/tachyons.min.css"
+        ] // concat app.css last
       }
     },
     templates: {


### PR DESCRIPTION
Phoenix doesn't seem to use the compiled css files in the dev environment, so heroku looks different to localhost. This makes sure the files are compiled in the correct order