### PR TITLE
Email popup flash typo

### DIFF
--- a/web/templates/homepage/email_form.html.eex
+++ b/web/templates/homepage/email_form.html.eex
@@ -15,7 +15,7 @@
     <%= form_for @conn, spreadsheet_path(@conn, :submit_email) <> "#email_form", [as: :email], fn f -> %>
       <%= label f, :email, "Email:", class: "db mv1" %>
       <%= email_input(f, :email, class: "br2 pa2 mb2-l mb3 f5 fw3 ba w-100") %>
-      <p class="alert ma0 mb4 pa3 ba bw1-ns bg--lm-green b--lm-green" role="alert"><%= get_flash(@conn, :email) %></p>
+      <p class="alert ma0 mb4 pa3 ba bw1-ns bg--lm-green b--lm-green" role="alert"><%= get_flash(@conn, :emails) %></p>
       <div class="relative w-100 mt3">
         <%= component "Buttons/primary_button", value: "Take part", class: "absolute bottom--1 right-0" %>
       </div>


### PR DESCRIPTION
Fixes typo causing email send flash to not show up

To reproduce, send your email from running the master branch locally - no flash
Running this branch - flash 👍 