### PR TITLE
Separating alpha blocks

### DIFF
--- a/web/controllers/feedback_controller.ex
+++ b/web/controllers/feedback_controller.ex
@@ -30,9 +30,13 @@ defmodule App.FeedbackController do
                  form_title: handle_bold(feedback_content.form_title),
                  feedback1: handle_bold(feedback_content.feedback1),
                  feedback2: handle_bold(feedback_content.feedback2),
-                 content: [:alphatext, :footer]
-                          |> Map.new(&({&1, R.get_content(&1)}))
-                          |> handle_bold
+                 content: %{footer: R.get_content(:footer),
+                            alpha: R.get_content(:alpha,
+                                                 {"/home/feedback/",
+                                                  "feedback_feedbackpage"}),
+                            alphatext: R.get_content(:alphatext,
+                                                 {"/home/feedback/",
+                                                  "feedback_feedbackpage"})}
   end
 
   def handle_bold(string) when is_binary(string),

--- a/web/controllers/homepage_controller.ex
+++ b/web/controllers/homepage_controller.ex
@@ -73,7 +73,7 @@ defmodule App.HomepageController do
     true
   """
   def get_content do
-    [:body, :footer, :alphatext, :lookingfor]
+    [:body, :footer, :alpha, :alphatext, :lookingfor]
     |> Map.new(&({&1, R.get_content(&1)}))
   end
 

--- a/web/controllers/resources.ex
+++ b/web/controllers/resources.ex
@@ -40,16 +40,26 @@ defmodule App.Resources do
   defp add_bold_class({tag, inner_html}, class),
     do: String.replace "<#{tag}>#{inner_html}</#{tag}>", "<b>", ~s(<b class="#{class}">)
 
-  def get_content(content) do
-    query = from page in "wagtailcore_page",
-      where: page.url_path == "/home/",
-      join: h in "home_homepage",
-      where: h.page_ptr_id == page.id,
-      select: %{alphatext: h.alphatext,
-                body: h.body,
-                footer: h.footer,
-                lookingfor: h.lookingfor}
-
+  def get_content(content,
+                  {url_path, table_name} \\ {"/home/", "home_homepage"}) do
+    query = case url_path do
+      "/home/" ->
+        from page in "wagtailcore_page",
+          where: page.url_path == ^url_path,
+          join: h in ^table_name,
+          where: h.page_ptr_id == page.id,
+          select: %{alphatext: h.alphatext,
+                    alpha: h.alpha,
+                    body: h.body,
+                    footer: h.footer,
+                    lookingfor: h.lookingfor}
+      "/home/feedback/" ->
+        from page in "wagtailcore_page",
+          where: page.url_path == ^url_path,
+          join: h in ^table_name,
+          where: h.page_ptr_id == page.id,
+          select: %{alphatext: h.alphatext, alpha: h.alpha}
+      end
     query
     |> CMSRepo.one
     |> Map.get(content)

--- a/web/static/css/app.css
+++ b/web/static/css/app.css
@@ -325,6 +325,22 @@ code {
   font-family: 'Segoe UI-Bold';
 }
 
+#alpha h2, h3 {
+  display: block;
+  font-size: 1.5em;
+  margin-top: 0.83em;
+  margin-bottom: 0.83em;
+  margin-left: 0;
+  margin-right: 0;
+  font-weight: bold;
+} /* default styling for a h2 taken from https://www.w3schools.com/tags/tag_hn.asp */
+
+@media only screen and (min-width: 30em) {
+  #alpha h2, h3 {
+    font-size: 1.25rem;
+  }
+}
+
 #alphasection ul {
   margin: 2rem 0;
   list-style-type: none;

--- a/web/templates/component/alpha_section.html.eex
+++ b/web/templates/component/alpha_section.html.eex
@@ -1,17 +1,19 @@
 <section class="lm-white lm-bg-dark-blue pa1 ph4 ph3-m ph3-l pb4 pb5-l" id="email_form">
   <div class="mh3 mv3 w-60-m w-50-l center" id="alpha">
-    <h2 class="f4 f4-ns mb0">ALPHA</h2>
-    <h2 class="f5 f4-ns mt1">what does it mean?</h2>
-    <p>The “alpha” phase is all about testing ideas and gathering feedback from the people that will be using the service.</p>
-
-    <p>Everything you see now can change based on what you think works and doesn’t work, so please let us know!</p>
-
-    <p>Any feedback you give us will be used to improve the content and functionality of the service, as well as the way the service looks</p>
+    <%= if @content[:alpha] do %>
+      <%= raw @content[:alpha] %>
+    <% else %>
+      <%= raw @content[:alpha_feedback] %>
+    <% end %>
   </div>
 
   <%= if @show_email_submit do %>
     <div id="alphasection" class="lm-dark-blue lm-bg-white mh3 ph3 pv1 ph4-l pv3-l w-60-m w-50-l center tracked relative">
-    <%= raw @content.alphatext %>
+      <%= if @content[:alphatext] do %>
+        <%= raw @content[:alphatext] %>
+      <% else %>
+        <%= raw @content[:alphatext_feedback] %>
+      <% end %>
       <%= form_for @conn, spreadsheet_path(@conn, :submit) <> "#email_form", [as: :email, id: "email-submit"], fn f -> %>
         <%= if get_flash(@conn, :emails) do %>
           <p class="alert ma0 mb4 mr1 pa3 ba bw1-ns bg--lm-green b--lm-green relative" role="alert">


### PR DESCRIPTION
See #260 

In this pr:
+ separating out the two alpha blocks so the content can be different
+ Adding all of the content so that it is editable from the cms

Although the functionality and ux has been achieved, the code should be tidied up.
+ `R.get_content` should have a better signature
+ `R.get_content` should be more flexible
+ the code in `R.get_content` should be tidied up

Will work on this in a separate pr, issue raised in #287 