### PR TITLE
Editable Content from CMS

### DIFF
--- a/test/controllers/banner_test.exs
+++ b/test/controllers/banner_test.exs
@@ -1,4 +1,4 @@
 defmodule App.BannerTest do
   use App.ConnCase, async: false
-  doctest App.Banner
+  doctest App.Banner, import: true
 end

--- a/test/controllers/banner_test.exs
+++ b/test/controllers/banner_test.exs
@@ -1,0 +1,4 @@
+defmodule App.BannerTest do
+  use App.ConnCase, async: false
+  doctest App.Banner
+end

--- a/test/controllers/info_controller_test.exs
+++ b/test/controllers/info_controller_test.exs
@@ -1,13 +1,13 @@
 defmodule App.InfoControllerTest do
   use App.ConnCase
 
-  test "GET /info/crisis", %{conn: conn} do
-    conn = get conn, "/info/crisis"
+  test "GET /crisis", %{conn: conn} do
+    conn = get conn, "/crisis"
     assert html_response(conn, 200) =~ "ALPHA"
   end
 
-  test "GET /info/notfound", %{conn: conn} do
-    conn = get conn, "/info/notfound"
+  test "GET /notfound", %{conn: conn} do
+    conn = get conn, "/notfound"
     assert html_response(conn, 404)
   end
 end

--- a/test/views/view_helpers_test.exs
+++ b/test/views/view_helpers_test.exs
@@ -1,7 +1,7 @@
 defmodule App.ViewHelpersTest do
   use App.ConnCase
 
-  import App.ViewHelpers, only: [render_image: 2, render_link: 1]
+  import App.ViewHelpers
 
   setup %{conn: conn} do
     conn =
@@ -34,14 +34,21 @@ defmodule App.ViewHelpersTest do
 
   test "transform single link" do
     actual = render_link(~s(<a id="30" linktype="page">link</a>))
-    expected = ~s(<a href="/info/crisis">link</a>)
+    expected = ~s(<a href="/crisis" class="">link</a>)
 
     assert actual == expected
   end
 
   test "transform multiple links" do
     actual = render_link(~s(<div><a id="30" linktype="page">link</a></div><div><a id="30" linktype="page">link2</a></div>))
-    expected = ~s(<div><a href="/info/crisis">link</a></div><div><a href="/info/crisis">link2</a></div>)
+    expected = ~s(<div><a href="/crisis" class="">link</a></div><div><a href="/crisis" class="">link2</a></div>)
+
+    assert actual == expected
+  end
+
+  test "transform link with class" do
+    actual = render_link(~s(<a id="30" linktype="page">link</a>), "f5 white")
+    expected = ~s(<a href="/crisis" class="f5 white">link</a>)
 
     assert actual == expected
   end

--- a/web/controllers/banner.ex
+++ b/web/controllers/banner.ex
@@ -1,0 +1,19 @@
+defmodule App.Banner do
+  @moduledoc false
+  import Plug.Conn
+  alias App.{Resources}
+
+  @doc"""
+    iex>App.Banner.init(true)
+    true
+  """
+  def init(args), do: args
+
+  def call(conn, _) do
+    assign(conn, :banner, get_banner_text())
+  end
+
+  def get_banner_text do
+    Resources.get_content(:banner)
+  end
+end

--- a/web/controllers/banner.ex
+++ b/web/controllers/banner.ex
@@ -1,10 +1,13 @@
 defmodule App.Banner do
-  @moduledoc false
+  @moduledoc """
+  # Gets banner text from CMS database, then assigns it to the connection
+  # so it's available in all templates
+  """
   import Plug.Conn
   alias App.{Resources}
 
   @doc"""
-    iex>App.Banner.init(true)
+    iex>init(true)
     true
   """
   def init(args), do: args

--- a/web/controllers/homepage_controller.ex
+++ b/web/controllers/homepage_controller.ex
@@ -69,7 +69,18 @@ defmodule App.HomepageController do
     true
   """
   def get_content,
-    do: R.get_content([:body, :footer, :alpha, :alphatext, :lookingfor])
+    do: R.get_content([
+      :body,
+      :footer,
+      :alpha,
+      :alphatext,
+      :lookingfor,
+      :filter_label_1,
+      :filter_label_2,
+      :filter_label_3,
+      :assessment_text,
+      :crisis_text
+    ])
 
   @doc"""
     iex>%{audience: audience, category: category, content: content} = get_tags()

--- a/web/router.ex
+++ b/web/router.ex
@@ -7,6 +7,7 @@ defmodule App.Router do
     plug :fetch_flash
     plug :protect_from_forgery
     plug :put_secure_browser_headers
+    plug App.Banner, ""
     plug App.Cookie, ""
   end
 
@@ -26,10 +27,11 @@ defmodule App.Router do
     post "/resourcefeedback/:id", ResourceFeedbackController, :resource_feedback
     get "/article/:id", ArticleController, :show
     get "/styleguide", StyleGuideController, :index
-    get "/info/:page", InfoController, :index
     get "/coming-soon", ComingSoonController, :index
     get "/feedback", FeedbackController, :index
     post "/feedback", FeedbackController, :post
+    get "/:page", InfoController, :index
+    # Default route - will match any page - must stay at bottom
   end
 
   # Other scopes may use custom stacks.

--- a/web/static/css/app.css
+++ b/web/static/css/app.css
@@ -57,6 +57,14 @@ body {
   font-family: 'NunitoSans-Italic';
 }
 
+a {
+  color: inherit;
+}
+
+.banner p {
+  margin: 0;
+}
+
 h1, h2 {
   font-family: 'Segoe UI', sans-serif;
 }
@@ -331,7 +339,7 @@ code {
   font-family: 'Segoe UI-Bold';
 }
 
-#alpha h2, h3 {
+#alpha h2, #alpha h3 {
   display: block;
   font-size: 1.5em;
   margin-top: 0.83em;

--- a/web/templates/homepage/index.html.eex
+++ b/web/templates/homepage/index.html.eex
@@ -5,17 +5,15 @@
   </div>
 </section>
 
-<section class="pt1 pb3 pt3-l pb4-l ph4 ph5-m ph6-l lm-bg-dark-blue tc">
-  <p class="white tl tc-l">
-    Take our <span class="b">clinically approved</span> sleep self-assessment
-  </p>
+<section class="pt1 pb3 pt3-l pb4-l ph4 ph5-m ph6-l lm-bg-dark-blue tc white">
+  <%= raw @content.assessment_text %>
   <%= component "buttons/secondary_button", background: "dark", value: "Take assessment", to: "/coming-soon", id: "assessment" %>
 </section>
 
 <section>
   <div class="lm-bg-orange pa3 ph4 tc">
     <p class="ma0 w-100 tc">
-      <%= link "Get urgent support", to: "info/crisis", class: "lm-dark-turquoise segoe-bold lm-white-hover", id: "crisis-link" %>
+      <%= link @content.crisis_text, to: "info/crisis", class: "lm-dark-turquoise segoe-bold lm-white-hover", id: "crisis-link" %>
     </p>
   </div>
 </section>
@@ -23,7 +21,11 @@
 <div class="tc">
   <%= checkbox :filter, :filter, class: "filter-check absolute o-0" %>
   <%= label :filter, :filter, class: get_class("primary_button") <> " mt4" %>
-  <%= render "sidebar.html", conn: @conn, tags: @tags %>
+  <%= render "sidebar.html", conn: @conn, tags: @tags,
+    filter_label_1: @content.filter_label_1,
+    filter_label_2: @content.filter_label_2,
+    filter_label_3: @content.filter_label_3
+  %>
 </div>
 
 <section class="tc-ns" id="results">

--- a/web/templates/homepage/sidebar.html.eex
+++ b/web/templates/homepage/sidebar.html.eex
@@ -8,19 +8,19 @@
     <div class="ph1 sidebar-tag-blocks">
       <%= form_for @conn, homepage_path(@conn, :show) <> "#results", [as: :tags, id: "filter-form"],  fn f -> %>
       <div class="mb5 relative">
-        <h4 class="w-70 mb1 mt2">Are you currently experiencing any of the following?</h4>
+        <h4 class="w-70 mb1 mt2"><%= @filter_label_1 %></h4>
         <%= inputs_for f, :category, [as: :category], fn fcat -> %>
           <%= render App.HomepageView, "tag-block.html", conn: @conn, tags: @tags, type: "category", form: fcat %>
         <% end %>
       </div>
       <div class="mv5 relative">
-        <h4 class="w-70 mt4 mb1">Is anything in particular affecting your sleep?</h4>
+        <h4 class="w-70 mt4 mb1"><%= @filter_label_2 %></h4>
         <%= inputs_for f, :audience, [as: :audience], fn fa -> %>
           <%= render App.HomepageView, "tag-block.html", conn: @conn, tags: @tags, type: "audience", form: fa %>
         <% end %>
       </div>
       <div class="mv5 relative">
-        <h4 class="w-70 mt4 mb1">What type of support are you looking for?</h4>
+        <h4 class="w-70 mt4 mb1"><%= @filter_label_3 %></h4>
         <%= inputs_for f, :content, [as: :content], fn fcon -> %>
           <%= render App.HomepageView, "tag-block.html", conn: @conn, tags: @tags, type: "content", form: fcon %>
         <% end %>

--- a/web/templates/layout/app.html.eex
+++ b/web/templates/layout/app.html.eex
@@ -39,9 +39,11 @@
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
     <div class="container">
-      <div class="pa3 lm-bg-dark-blue lm-white w-100 f6 f5-l f5-m banner segoe">
-        <%= @banner |> render_link("underline lm-white") |> raw %>
-      </div>
+      <%= if String.length(@banner) > 0  do %>
+        <div class="pa3 lm-bg-dark-blue lm-white w-100 f6 f5-l f5-m banner segoe">
+          <%= @banner |> render_link("underline lm-white") |> raw %>
+        </div>
+      <% end %>
       <p class="alert" role="alert"><%= get_flash @conn, :info %></p>
       <p class="alert" role="alert"><%= get_flash @conn, :error %></p>
 

--- a/web/templates/layout/app.html.eex
+++ b/web/templates/layout/app.html.eex
@@ -39,22 +39,8 @@
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
     <div class="container">
-      <div class="pa3 lm-bg-dark-blue lm-white w-100">
-        <h2 class="ma0 f6 f5-l f5-m">
-          <span class="b">ALPHA:</span>
-          This is a prototype - your
-          <%= if @conn.request_path != "/feedback" do %>
-            <a href="/feedback" id="feedback-link" class="underline lm-white">feedback</a>
-          <% else %>
-            <span class="lm-white">feedback</span>
-          <% end %>
-          will help us to improve it.
-          <%= if @conn.request_path != "/feedback" do %>
-            <a href="/#alpha" class="underline lm-white">Find out more</a>
-          <% else %>
-            <span>Find out more</span>
-          <% end %>
-        </h2>
+      <div class="pa3 lm-bg-dark-blue lm-white w-100 f6 f5-l f5-m banner segoe">
+        <%= @banner |> render_link("underline lm-white") |> raw %>
       </div>
       <p class="alert" role="alert"><%= get_flash @conn, :info %></p>
       <p class="alert" role="alert"><%= get_flash @conn, :error %></p>

--- a/web/views/view_helpers.ex
+++ b/web/views/view_helpers.ex
@@ -45,10 +45,13 @@ defmodule App.ViewHelpers do
     end
   end
 
-  def render_link(html_string),
-    do: Regex.replace @link_regex, html_string, &get_a_tag/3, global: true
+  def render_link(html_string, classes \\ "") do
+    Regex.replace(@link_regex, html_string,
+      &get_a_tag(&1, &2, &3, classes), global: true
+    )
+  end
 
-  def get_a_tag(_full_string, id, text) do
+  def get_a_tag(_full_string, id, text, classes) do
     link_query = from p in "wagtailcore_page",
       where: p.id == ^String.to_integer(id),
       join: c in "django_content_type",
@@ -57,7 +60,7 @@ defmodule App.ViewHelpers do
 
     data = CMSRepo.one(link_query)
 
-    ~s(<a href="/#{data.content}/#{data.page}">#{text}</a>)
+    ~s(<a href="/#{data.page}" class="#{classes}">#{text}</a>)
   end
 
   @button_classes "f5 link dib ph3 pv2 br-pill lm-white-hover pointer segoe-bold tracked"


### PR DESCRIPTION
### To be merged after #299 
ref #238: Fetches new content from CMS
 * Uses a Plug to fetch banner text, so it is available on all templates
 * Fetches filter titles, link text for crisis and assessment