### PR TITLE
Sidebar shows on top of alpha banner

### DIFF
--- a/web/templates/homepage/sidebar.html.eex
+++ b/web/templates/homepage/sidebar.html.eex
@@ -1,5 +1,5 @@
 <div class="filter-sidebar">
-  <div class="fixed sidebar top-0 bg-white bottom-0 w-80 w-70-ns w-50-m w-30-l pa3 overflow-y-scroll tl shadow-2">
+  <div class="fixed sidebar top-0 bg-white bottom-0 w-80 w-70-ns w-50-m w-30-l pa3 overflow-y-scroll tl shadow-2 z-9999">
     <div class="tl lm-grey w-100 tr mb4">
       <%= label :filter, :filter, class: get_class("secondary_button", "light") do
         raw("<i class=\"fa fa-times f4\" aria-hidden=\"true\"></i>")
@@ -34,4 +34,4 @@
     </div>
   </div>
 </div>
-<div class="fixed top-0 bottom-0 w-100 sidebar-overlay dn bg-gray o-70"></div>
+<div class="fixed top-0 bottom-0 w-100 sidebar-overlay dn bg-gray o-70 z-999"></div>

--- a/web/templates/layout/app.html.eex
+++ b/web/templates/layout/app.html.eex
@@ -43,7 +43,7 @@
         <div class="pa3 lm-bg-dark-blue lm-white w-100 f6 f5-l f5-m banner segoe">
           <%= @banner |> render_link("underline lm-white") |> raw %>
         </div>
-        <div class="pa3 lm-bg-dark-blue lm-white w-100 f6 f5-l f5-m banner segoe fixed top-0 z-999">
+        <div class="pa3 lm-bg-dark-blue lm-white w-100 f6 f5-l f5-m banner segoe fixed top-0 z-5">
           <%= @banner |> render_link("underline lm-white") |> raw %>
         </div>
       <% end %>


### PR DESCRIPTION
See [comment](https://github.com/LDMW/app/issues/310#issuecomment-307105791) for #301 

Adding higher z-index's for the sidebar so it shows above the alpha banner and lowering the alpha banner's z-index