### PR TITLE
adds options for adding ids to wagtail rendered links

### DIFF
--- a/test/views/view_helpers_test.exs
+++ b/test/views/view_helpers_test.exs
@@ -34,21 +34,28 @@ defmodule App.ViewHelpersTest do
 
   test "transform single link" do
     actual = render_link(~s(<a id="30" linktype="page">link</a>))
-    expected = ~s(<a href="/crisis" class="">link</a>)
+    expected = ~s(<a href="/crisis" class="" id="">link</a>)
 
     assert actual == expected
   end
 
   test "transform multiple links" do
     actual = render_link(~s(<div><a id="30" linktype="page">link</a></div><div><a id="30" linktype="page">link2</a></div>))
-    expected = ~s(<div><a href="/crisis" class="">link</a></div><div><a href="/crisis" class="">link2</a></div>)
+    expected = ~s(<div><a href="/crisis" class="" id="">link</a></div><div><a href="/crisis" class="" id="">link2</a></div>)
 
     assert actual == expected
   end
 
   test "transform link with class" do
-    actual = render_link(~s(<a id="30" linktype="page">link</a>), "f5 white")
-    expected = ~s(<a href="/crisis" class="f5 white">link</a>)
+    actual = render_link(~s(<a id="30" linktype="page">link</a>), class: "f5 white")
+    expected = ~s(<a href="/crisis" class="f5 white" id="">link</a>)
+
+    assert actual == expected
+  end
+
+  test "transform link with id" do
+    actual = render_link(~s(<a id="30" linktype="page">link</a>), id: "hello")
+    expected = ~s(<a href="/crisis" class="" id="hello">link</a>)
 
     assert actual == expected
   end

--- a/web/static/css/app.css
+++ b/web/static/css/app.css
@@ -334,6 +334,9 @@ code {
     height: 21.2rem;
   }
 }
+.crisis-banner > p {
+  margin: 0;
+}
 
 #email_form h2 {
   font-family: 'Segoe UI-Bold';

--- a/web/templates/homepage/index.html.eex
+++ b/web/templates/homepage/index.html.eex
@@ -11,10 +11,8 @@
 </section>
 
 <section>
-  <div class="lm-bg-orange pa3 ph4 tc">
-    <p class="ma0 w-100 tc">
-      <%= link @content.crisis_text, to: "info/crisis", class: "lm-dark-turquoise segoe-bold lm-white-hover", id: "crisis-link" %>
-    </p>
+  <div class="lm-bg-orange pa3 ph4 tc ma0 w-100 tc lm-dark-turquoise crisis-banner">
+    <%= @content.crisis_text |> render_link(id: "crisis-link", class: "lm-white-hover") |> raw %>
   </div>
 </section>
 

--- a/web/templates/layout/app.html.eex
+++ b/web/templates/layout/app.html.eex
@@ -41,10 +41,10 @@
     <div class="container">
       <%= if String.length(@banner) > 0  do %>
         <div class="pa3 lm-bg-dark-blue lm-white w-100 f6 f5-l f5-m banner segoe">
-          <%= @banner |> render_link("underline lm-white") |> raw %>
+          <%= @banner |> render_link() |> raw %>
         </div>
         <div class="pa3 lm-bg-dark-blue lm-white w-100 f6 f5-l f5-m banner segoe fixed top-0">
-          <%= @banner |> render_link("underline lm-white") |> raw %>
+          <%= @banner |> render_link(class: "underline lm-white", id: "feedback-link") |> raw %>
         </div>
       <% end %>
       <p class="alert" role="alert"><%= get_flash @conn, :info %></p>

--- a/web/views/view_helpers.ex
+++ b/web/views/view_helpers.ex
@@ -45,13 +45,13 @@ defmodule App.ViewHelpers do
     end
   end
 
-  def render_link(html_string, classes \\ "") do
+  def render_link(html_string, opts \\ %{}) do
     Regex.replace(@link_regex, html_string,
-      &get_a_tag(&1, &2, &3, classes), global: true
+      &get_a_tag(&1, &2, &3, opts[:class], opts[:id]), global: true
     )
   end
 
-  def get_a_tag(_full_string, id, text, classes) do
+  def get_a_tag(_full_string, id, text, classes \\ "", html_id \\ "") do
     link_query = from p in "wagtailcore_page",
       where: p.id == ^String.to_integer(id),
       join: c in "django_content_type",
@@ -60,7 +60,7 @@ defmodule App.ViewHelpers do
 
     data = CMSRepo.one(link_query)
 
-    ~s(<a href="/#{data.page}" class="#{classes}">#{text}</a>)
+    ~s(<a href="/#{data.page}" class="#{classes}" id="#{html_id}">#{text}</a>)
   end
 
   @button_classes "f5 link dib ph3 pv2 br-pill lm-white-hover pointer segoe-bold tracked"


### PR DESCRIPTION
ref #238
When we're taking links from wagtail, they don't have their ids attached. This PR adds a function for easy adding of ids and classes to links which will help with tracking on GA