### PR TITLE
only compress static files in production

### DIFF
--- a/lib/app/endpoint.ex
+++ b/lib/app/endpoint.ex
@@ -8,7 +8,7 @@ defmodule App.Endpoint do
   # You should set gzip to true if you are running phoenix.digest
   # when deploying your static files in production.
   plug Plug.Static,
-    at: "/", from: :app, gzip: true,
+    at: "/", from: :app, gzip: Mix.env == :prod,
     only: ~w(css fonts images js favicon.png robots.txt)
 
   # Code reloading can be explicitly enabled under the


### PR DESCRIPTION
To speed up page load for #359, I added gzip: true to compress static files. This meant we needed to run mix.digest every time we changed any of the js or css files. This pr makes it so that gzip compression only happens in production