### PR TITLE
Unliking iphone bug

### DIFF
--- a/web/static/css/app.css
+++ b/web/static/css/app.css
@@ -279,29 +279,21 @@ footer p a {
 
 /* Landing Page - resource like buttons */
 
-.like {
+.like, .like_no_hover {
   background-image: url("../images/Thumbs_up_normal.svg");
   background-repeat: no-repeat;
 }
 
-.like:hover {
+.like:hover, .liked {
   background-image: url("../images/Thumbs_up_hover.svg");
 }
 
-.liked {
-  background-image: url("../images/Thumbs_up_hover.svg");
-}
-
-.dislike {
+.dislike, .dislike_no_hover {
   background-image: url("../images/Thumbs_down_normal.svg");
   background-repeat: no-repeat;
 }
 
-.dislike:hover {
-  background-image: url("../images/Thumbs_down_hover.svg");
-}
-
-.disliked {
+.dislike:hover, .disliked {
   background-image: url("../images/Thumbs_down_hover.svg");
 }
 

--- a/web/static/js/like.js
+++ b/web/static/js/like.js
@@ -16,11 +16,28 @@ if (isNotIE8()) {
 
         resource.innerHTML = response.result;
         resource.addEventListener("submit", formListener);
-        analytics.addAnalytics(select(".like", resource), "Like", "liked");
-        analytics.addAnalytics(select(".dislike", resource), "Dislike", "disliked");
+        analytics.addAnalytics(select("button[name='like']", resource), "Like", "liked");
+        analytics.addAnalytics(select("button[name='dislike']", resource), "Dislike", "disliked");
         analytics.addAnalytics(select(".share", resource), "Share", "shared");
         analytics.addAnalytics(select(".resource-feedback", resource), "ResourceFeedback", "reviewed");
+        handle_ios();
       });
     }
   };
 }
+
+function handle_ios_likes (like) {
+  selectAll("button[name='" + like + "']").forEach(function (el) {
+    if (el.className.indexOf(like + '_no_hover') === -1) {
+      toggleClasses(el, [like, like + '_no_hover'])
+    }
+  });
+}
+
+function handle_ios () {
+  if (navigator.platform && /iPad|iPhone|iPod/.test(navigator.platform)) {
+    ['like', 'dislike'].forEach(handle_ios_likes);
+  }
+}
+
+handle_ios();

--- a/web/templates/homepage/resource.html.eex
+++ b/web/templates/homepage/resource.html.eex
@@ -28,10 +28,10 @@
       <div class="w-60 dib">
         <div class="dib mb3 v-mid tl"><span><%= @resource.likes %></span></div>
         <%= form_for @conn, likes_path(@conn, :like, @resource.id) <> "#resource_#{@resource.id}", [as: :like, class: "dib like-form mr1"], fn _f -> %>
-          <button type="submit" class="<%= check_liked "like", @resource.liked %> w2 h2 bn bg-white fl p0 bg-left pointer" data-url="<%= @resource.url %>"><span class="absolute o-0">Recommend</span></button>
+          <button name="like" type="submit" class="<%= check_liked "like", @resource.liked %> w2 h2 bn bg-white fl p0 bg-left pointer" data-url="<%= @resource.url %>"><span class="absolute o-0">Recommend</span></button>
         <%= end %>
         <%= form_for @conn, likes_path(@conn, :dislike, @resource.id) <> "#resource_#{@resource.id}", [as: :dislike, class: "dib dislike-form"], fn _f -> %>
-          <button type="submit" class="<%= check_liked "dislike", @resource.liked %> w2 h2 bn bg-white p0 bg-right pointer" data-url="<%= @resource.url %>"><span class="absolute o-0">Don't Recommend</span></button>
+          <button name="dislike" type="submit" class="<%= check_liked "dislike", @resource.liked %> w2 h2 bn bg-white p0 bg-right pointer" data-url="<%= @resource.url %>"><span class="absolute o-0">Don't Recommend</span></button>
         <%= end %>
         <div class="dib mb3 v-mid tl"><span><%= @resource.dislikes %></span></div>
       </div>


### PR DESCRIPTION
See #385

+ Changed how we reference our `like` buttons from `.like` to `button[name=like]` so that we have more freedom of adding and removing classes while ensuring consistent referencing to the button and added a `name` to the `like` buttons
+ Added a `handle_ios` function which initially and on every form submit (click of a like), this ensures that on iphone/ipod/ipad we won't have a hover state as this isn't reliable