### PR TITLE
fixes bug where search was not working with multi-word tags

### DIFF
--- a/test/controllers/search_test.exs
+++ b/test/controllers/search_test.exs
@@ -26,4 +26,16 @@ defmodule App.SearchTest do
     |> Enum.filter(&(Search.find_matches &1, Search.split_text "community"))
     |> length == 2
   end
+
+  test "Search - multiple word tags" do
+    assert resources()
+    |> Enum.filter(&(Search.find_matches &1, Search.split_text "sleep deprivation"))
+    |> length == 1
+  end
+
+  test "Search - multiple word tags with stop words" do
+    assert resources()
+    |> Enum.filter(&(Search.find_matches &1, Search.split_text "peer to peer"))
+    |> length == 1
+  end
 end

--- a/test/fixtures/search_fixtures.ex
+++ b/test/fixtures/search_fixtures.ex
@@ -28,6 +28,13 @@ defmodule App.SearchFixtures do
         tags: %{"reason" => ["all-reason"],
           "issue" => ["insomnia", "all-issue"],
           "content" => ["all-content", "CBT", "app", "free-trial", "mindfulness", "peer-to-peer", "subscription"]}
+      },
+      %{
+        body: "<p>Tips for sleeping</p>", dislikes: 0,
+        heading: "Tips", id: 9, liked: "none", likes: 1, priority: 5,
+        tags: %{"reason" => ["all-reason"],
+          "issue" => ["insomnia", "all-issue"],
+          "content" => ["all-content", "sleep deprivation"]}
       }
     ]
   end

--- a/web/controllers/search.ex
+++ b/web/controllers/search.ex
@@ -29,10 +29,10 @@ defmodule App.Search do
 
   def find_matches(string1, string2)
   when is_binary string1 and is_binary string2 do
-    String.jaro_distance(
-      String.downcase(string1),
-      string2 |> String.replace(" ", "-") |> String.downcase
-    ) > 0.88
+    string1
+    |> String.downcase
+    |> String.split(~r/[\-\s]/)
+    |> Enum.any?(&(String.jaro_distance(&1, String.downcase(string2)) > 0.88))
   end
 
   def split_text(text) do


### PR DESCRIPTION
#464 
When upgrading the search to search full text, it caused multiple word tags to not work any more. Fixing this by searching through each word in the tag, whether separated with dashes or spaces.